### PR TITLE
Improve error messages in ulex parsing

### DIFF
--- a/prolog/lexicon/ulex.pl
+++ b/prolog/lexicon/ulex.pl
@@ -75,7 +75,9 @@ read_ulex(LexiconStream) :-
 		),
 		_CatchType,
 		(
-			with_output_to(atom(Message), format("The user lexicon file is not a valid Prolog file.", [])),
+			line_count(LexiconStream, MalformedLine),
+			atom_concat("The use lexicon file is not a valid Prolog file. Check line ", MalformedLine, RepairMessage),
+			with_output_to(atom(Message), format(RepairMessage, [])),
 			add_error_message_once(lexicon, '', 'Malformed file.', Message)
 		)
 	),


### PR DESCRIPTION
This partially addresses issue #2. Malformed file errors will display
the line number of the line that is causing the error.