### PR TITLE
Janw

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /ape.exe
 /ape-*.zip
 /packages
+*~

--- a/prolog/ape.pl
+++ b/prolog/ape.pl
@@ -268,7 +268,8 @@ get_solo_content(SoloType, TempResult, ContentType, Content) :-
 	;
 		Content = OutputContent,
 		ContentType = OutputContentType
-	).
+	),
+	!.
 
 get_solo_content(SoloType, _, 'text/plain', 'ERROR: Unexpected error.') :-
 	output_type(SoloType),

--- a/prolog/ape.pl
+++ b/prolog/ape.pl
@@ -448,10 +448,10 @@ load_ulex(Input) :-
 	get_value(Input, ulextext, Ulex),
 	!,
 	discard_ulex,
-    atom_to_memory_file(Ulex, UlexHandle),
-    open_memory_file(UlexHandle, read, UlexStream),
-    read_ulex(UlexStream),
-    free_memory_file(UlexHandle).
+    setup_call_cleanup(
+	open_string(Ulex, UlexStream),
+	read_ulex(UlexStream),
+	close(UlexStream)).
 
 load_ulex(_).
 

--- a/prolog/lexicon/clex.pl
+++ b/prolog/lexicon/clex.pl
@@ -17,6 +17,7 @@
 		clex_switch/1,     % ?Switch
 		set_clex_switch/1  % +Switch
 	]).
+:- use_module(library(error)).
 
 /** <module> Common Lexicon Interface
 
@@ -90,6 +91,6 @@ clex_switch(on).
 % This predicate switches clex on (Switch='on') or off (Switch='off').
 
 set_clex_switch(Switch) :-
-    member(Switch, [on, off]),
+    must_be(oneof([on,off]), Switch),
     retractall(clex_switch(_)),
     assert(clex_switch(Switch)).

--- a/prolog/lexicon/ulex.pl
+++ b/prolog/lexicon/ulex.pl
@@ -79,11 +79,8 @@ read_ulex(LexiconStream) :-
 			with_output_to(atom(Message), format("The user lexicon file is not a valid Prolog file. Check line ~d", [MalformedLineNum])),
 			add_error_message_once(lexicon, '', 'Malformed file.', Message)
 		)
-	), !,
-	close(LexiconStream).
-
-read_ulex(LexiconStream) :-
-	close(LexiconStream).
+	), !.
+read_ulex(_).
 
 
 %% read_lexicon_entries(+Stream)
@@ -93,10 +90,10 @@ read_ulex(LexiconStream) :-
 read_lexicon_entries(Stream) :-
     read(Stream, LexEntry),
     ( LexEntry == end_of_file ->
-    	true
+	true
     ;
-    	add_lexicon_entry(LexEntry),
-    	read_lexicon_entries(Stream)
+	add_lexicon_entry(LexEntry),
+	read_lexicon_entries(Stream)
     ).
 
 

--- a/prolog/lexicon/ulex.pl
+++ b/prolog/lexicon/ulex.pl
@@ -79,7 +79,7 @@ read_ulex(LexiconStream) :-
 			with_output_to(atom(Message), format("The user lexicon file is not a valid Prolog file. Check line ~d", [MalformedLineNum])),
 			add_error_message_once(lexicon, '', 'Malformed file.', Message)
 		)
-	),
+	), !,
 	close(LexiconStream).
 
 read_ulex(LexiconStream) :-

--- a/prolog/parser/tokenizer.pl
+++ b/prolog/parser/tokenizer.pl
@@ -15,6 +15,7 @@
 :- module(tokenizer, [
 		tokenize/2
 	]).
+:- use_module(library(error)).
 
 :- use_module('../lexicon/chars', [
 		is_letter/1,
@@ -82,14 +83,18 @@ Example:
 %
 tokenize([], []) :- !.
 
-tokenize(Atom, Tokens) :-
-	atom(Atom),
+tokenize(Text, Tokens) :-
+	(   atom(Text)
+	->  atom_codes(Text, Codes)
+	;   string(Text)
+	->  string_codes(Text, Codes)
+	),
 	!,
-	atom_codes(Atom, Codes),
 	codes_to_tokens(Codes, Tokens).
 
-tokenize([C | Cs], Tokens) :-
-	codes_to_tokens([C | Cs], Tokens).
+tokenize(Codes, Tokens) :-
+	must_be(codes, Codes),
+	codes_to_tokens(Codes, Tokens).
 
 
 %% codes_to_tokens(+Codes:list, -Tokens:list) is det.

--- a/prolog/utils/drs_to_html.pl
+++ b/prolog/utils/drs_to_html.pl
@@ -35,8 +35,6 @@
 :- op(500, xfx, =>).
 :- op(500, xfx, v).
 
-:- style_check(-atom).
-
 
 %% drs_to_html(+Drs:term, -DrsHtml:atom) is det.
 %

--- a/tests/rtest.bash
+++ b/tests/rtest.bash
@@ -20,8 +20,6 @@ prolog=swipl
 #downloader='curl -o'
 downloader='wget -O'
 
-clex='clex_lexicon.pl'
-
 echo "Using: `$prolog --version`"
 
 # Generate a timestamp.
@@ -36,12 +34,6 @@ echo "Downloading the latest ACE text set ... "
 $downloader acetexts.pl http://attempto.ifi.uzh.ch/cgi-bin/acetextset/get_acetexts.cgi
 echo "done."
 fi
-fi
-
-
-if [ ! -f $clex ]; then
-	echo "Downloading the large Clex lexicon (from github.com/Attempto/Clex)"
-	$downloader $clex https://raw.github.com/Attempto/Clex/master/$clex
 fi
 
 # Creates a directory for the test results.

--- a/tests/test_drs_to_x.pl
+++ b/tests/test_drs_to_x.pl
@@ -108,4 +108,6 @@ check_and_output_error(time_limit_exceeded) :-
 	format("ERROR\t~w~n", ['Time limit exceeded']).
 
 check_and_output_error(error(Message, context(Pred, Arg))) :-
-	format("ERROR\t~w\t~w\t~w~n", [Message, Pred, Arg]).
+	\+ \+ ( numbervars(Arg, 0, _, [singletons(true)]),
+		format("ERROR\t~w\t~w\t~w~n", [Message, Pred, Arg])
+	      ).

--- a/tests/test_owlswrl.pl
+++ b/tests/test_owlswrl.pl
@@ -19,7 +19,7 @@
 :- use_module(ape('logger/error_logger'), [
 		clear_messages/0,
 		get_messages/1
-	]). 
+	]).
 
 :- use_module(ape('utils/xmlterm_to_xmlatom'), [
 		xmlterm_to_xmlatom/2
@@ -28,8 +28,6 @@
 :- use_module(ape('lexicon/ulex'), [
 		read_ulex/1
 	]).
-
-:- set_prolog_flag(float_format, '%.11g').
 
 t('1-1', 'Every man is a human.').
 t('1-2', 'Every man is somebody.').

--- a/tests/test_owlswrl.pl
+++ b/tests/test_owlswrl.pl
@@ -510,8 +510,11 @@ store_as_file(ID, Atom) :-
 
 set_up_lexicon :-
 	% Read the large lexicon into ulex
-	open('clex_lexicon.pl', read, Stream),
-	call_cleanup(read_ulex(Stream), close(Stream)),
+	absolute_file_name(ape('lexicon/clex_lexicon.pl'), CLex, [access(read)]),
+	setup_call_cleanup(
+	    open(CLex, read, Stream),
+	    read_ulex(Stream),
+	    close(Stream)),
 	% Override some entries
 	asserta(ulex:noun_sg(apple, 'iri|http://www.example.org/words#apple', neutr)),
 	asserta(ulex:pn_sg('Bill', iri('http://www.example.org/words#Bill'), neutr)).


### PR DESCRIPTION
Here is a new attempt.  Now executed `test_everything.sh`.  Only, I'm not sure how to evaluate.

  - The `tmp/now.txt` has no #, so that looks fine.
  - The test overwrites `tests/testruns/owlswrl_test_results.txt` and `tests/testruns/test_drs_to_tptp_out.txt`.  Git diff shows lots of differences, but most seem innocent.  I added 
b64f861 to avoid some differences in the future, but there also seem to be random bnode ids?
  - `cat testruns/drace_test_results.txt | grep "FAIL" | grep -v ":" | grep -v "ach of" | wc` shows `309    5174   24981`, but  I have no clue what that means.

Quite likely more will follow, notably to make APE more usable as a Prolog library.   Among others I'll probably look into making APE thread safe.   Would that be welcome?

P.s. Should the full clex lexicon not be default?  3.3M is so small these days ...
